### PR TITLE
Phase 2: GameSession Durable Object実装

### DIFF
--- a/packages/workers/.eslintignore
+++ b/packages/workers/.eslintignore
@@ -1,0 +1,3 @@
+.wrangler/
+dist/
+node_modules/

--- a/packages/workers/src/__tests__/GameSession.test.ts
+++ b/packages/workers/src/__tests__/GameSession.test.ts
@@ -1,0 +1,254 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { GameSession } from '../durable-objects/GameSession';
+import { GameSessionState, APIResponse } from '@majibattle/shared';
+
+// Mock DurableObjectState and SqlStorage
+const mockSqlStorage = {
+  exec: vi.fn(),
+};
+
+const mockState = {
+  storage: {
+    sql: mockSqlStorage,
+  },
+};
+
+const mockEnv = {
+  // eslint-disable-next-line no-undef
+  GAME_SESSION: {} as DurableObjectNamespace,
+};
+
+describe('GameSession Durable Object', () => {
+  let gameSession: GameSession;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    gameSession = new GameSession(mockState as any, mockEnv as any);
+  });
+
+  describe('Database Initialization', () => {
+    test('should initialize database table on first access', async () => {
+      mockSqlStorage.exec.mockResolvedValueOnce({ toArray: () => [] });
+
+      const request = new Request('http://localhost/create', { method: 'POST' });
+      await gameSession.fetch(request);
+
+      expect(mockSqlStorage.exec).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE TABLE IF NOT EXISTS game_sessions')
+      );
+    });
+  });
+
+  describe('createSession', () => {
+    test('should create new session with random kanji', async () => {
+      mockSqlStorage.exec
+        .mockResolvedValueOnce({ toArray: () => [] }) // CREATE TABLE
+        .mockResolvedValueOnce({ toArray: () => [] }); // INSERT
+
+      const request = new Request('http://localhost/create', { method: 'POST' });
+      const response = await gameSession.fetch(request);
+
+      expect(response.status).toBe(200);
+
+      const result = (await response.json()) as APIResponse<GameSessionState>;
+      expect(result.success).toBe(true);
+      expect(result.data).toBeTruthy();
+      if (result.data) {
+        expect(result.data.sessionId).toBeDefined();
+        expect(result.data.currentKanji).toHaveLength(20);
+        expect(result.data.selectedKanji).toEqual([]);
+        expect(result.data.spellHistory).toEqual([]);
+      }
+    });
+  });
+
+  describe('getState', () => {
+    test('should return existing session state', async () => {
+      const mockSessionData = {
+        session_id: 'test-session-id',
+        current_kanji: '["火","水","木"]',
+        selected_kanji: '["火"]',
+        spell_history: '[]',
+        created_at: Date.now(),
+        last_updated_at: Date.now(),
+      };
+
+      mockSqlStorage.exec
+        .mockResolvedValueOnce({ toArray: () => [] }) // CREATE TABLE
+        .mockResolvedValueOnce({ toArray: () => [mockSessionData] }); // SELECT
+
+      const request = new Request('http://localhost/state', { method: 'GET' });
+      const response = await gameSession.fetch(request);
+
+      expect(response.status).toBe(200);
+
+      const result = (await response.json()) as APIResponse<GameSessionState>;
+      expect(result.success).toBe(true);
+      expect(result.data?.sessionId).toBe('test-session-id');
+      expect(result.data?.currentKanji).toEqual(['火', '水', '木']);
+      expect(result.data?.selectedKanji).toEqual(['火']);
+    });
+
+    test('should return 404 when no session exists', async () => {
+      mockSqlStorage.exec
+        .mockResolvedValueOnce({ toArray: () => [] }) // CREATE TABLE
+        .mockResolvedValueOnce({ toArray: () => [] }); // SELECT
+
+      const request = new Request('http://localhost/state', { method: 'GET' });
+      const response = await gameSession.fetch(request);
+
+      expect(response.status).toBe(404);
+
+      const result = (await response.json()) as APIResponse<null>;
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('No session found');
+    });
+  });
+
+  describe('updateSelection', () => {
+    const mockSessionData = {
+      session_id: 'test-session-id',
+      current_kanji: '["火","水","木","金","土"]',
+      selected_kanji: '["火"]',
+      spell_history: '[]',
+      created_at: Date.now(),
+      last_updated_at: Date.now(),
+    };
+
+    test('should add valid kanji to selection', async () => {
+      mockSqlStorage.exec
+        .mockResolvedValueOnce({ toArray: () => [] }) // CREATE TABLE
+        .mockResolvedValueOnce({ toArray: () => [mockSessionData] }) // SELECT
+        .mockResolvedValueOnce({ toArray: () => [] }); // UPDATE
+
+      const request = new Request('http://localhost/select', {
+        method: 'POST',
+        body: JSON.stringify({ kanji: '水' }),
+      });
+      const response = await gameSession.fetch(request);
+
+      expect(response.status).toBe(200);
+
+      const result = (await response.json()) as APIResponse<GameSessionState>;
+      expect(result.success).toBe(true);
+      expect(result.data?.selectedKanji).toEqual(['火', '水']);
+    });
+
+    test('should reject duplicate kanji selection', async () => {
+      mockSqlStorage.exec
+        .mockResolvedValueOnce({ toArray: () => [] }) // CREATE TABLE
+        .mockResolvedValueOnce({ toArray: () => [mockSessionData] }); // SELECT
+
+      const request = new Request('http://localhost/select', {
+        method: 'POST',
+        body: JSON.stringify({ kanji: '火' }),
+      });
+      const response = await gameSession.fetch(request);
+
+      expect(response.status).toBe(400);
+
+      const result = (await response.json()) as APIResponse<null>;
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid kanji selection');
+    });
+
+    test('should reject kanji not in current selection', async () => {
+      mockSqlStorage.exec
+        .mockResolvedValueOnce({ toArray: () => [] }) // CREATE TABLE
+        .mockResolvedValueOnce({ toArray: () => [mockSessionData] }); // SELECT
+
+      const request = new Request('http://localhost/select', {
+        method: 'POST',
+        body: JSON.stringify({ kanji: '雷' }),
+      });
+      const response = await gameSession.fetch(request);
+
+      expect(response.status).toBe(400);
+
+      const result = (await response.json()) as APIResponse<null>;
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Kanji not available in current selection');
+    });
+
+    test('should reject selection when already 4 kanji selected', async () => {
+      const fullSelectionData = {
+        ...mockSessionData,
+        selected_kanji: '["火","水","木","金"]',
+      };
+
+      mockSqlStorage.exec
+        .mockResolvedValueOnce({ toArray: () => [] }) // CREATE TABLE
+        .mockResolvedValueOnce({ toArray: () => [fullSelectionData] }); // SELECT
+
+      const request = new Request('http://localhost/select', {
+        method: 'POST',
+        body: JSON.stringify({ kanji: '土' }),
+      });
+      const response = await gameSession.fetch(request);
+
+      expect(response.status).toBe(400);
+
+      const result = (await response.json()) as APIResponse<null>;
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid kanji selection');
+    });
+  });
+
+  describe('resetSession', () => {
+    test('should reset session with new kanji and clear selections', async () => {
+      const mockSessionData = {
+        session_id: 'test-session-id',
+        current_kanji: '["火","水","木"]',
+        selected_kanji: '["火","水"]',
+        spell_history: '[]',
+        created_at: Date.now(),
+        last_updated_at: Date.now(),
+      };
+
+      mockSqlStorage.exec
+        .mockResolvedValueOnce({ toArray: () => [] }) // CREATE TABLE
+        .mockResolvedValueOnce({ toArray: () => [mockSessionData] }) // SELECT
+        .mockResolvedValueOnce({ toArray: () => [] }); // UPDATE
+
+      const request = new Request('http://localhost/reset', { method: 'POST' });
+      const response = await gameSession.fetch(request);
+
+      expect(response.status).toBe(200);
+
+      const result = (await response.json()) as APIResponse<GameSessionState>;
+      expect(result.success).toBe(true);
+      expect(result.data?.selectedKanji).toEqual([]);
+      expect(result.data?.currentKanji).toHaveLength(20);
+      expect(result.data?.sessionId).toBe('test-session-id');
+    });
+  });
+
+  describe('Error Handling', () => {
+    test('should handle database errors gracefully', async () => {
+      mockSqlStorage.exec.mockRejectedValueOnce(new Error('Database error'));
+
+      const request = new Request('http://localhost/create', { method: 'POST' });
+      const response = await gameSession.fetch(request);
+
+      expect(response.status).toBe(500);
+
+      const result = (await response.json()) as APIResponse<null>;
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Internal server error');
+    });
+
+    test('should return 404 for unknown endpoints', async () => {
+      mockSqlStorage.exec.mockResolvedValueOnce({ toArray: () => [] });
+
+      const request = new Request('http://localhost/unknown', { method: 'GET' });
+      const response = await gameSession.fetch(request);
+
+      expect(response.status).toBe(404);
+
+      const result = (await response.json()) as APIResponse<null>;
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Not found');
+    });
+  });
+});

--- a/packages/workers/src/durable-objects/GameSession.ts
+++ b/packages/workers/src/durable-objects/GameSession.ts
@@ -1,0 +1,243 @@
+import { GameSessionState, APIResponse } from '@majibattle/shared';
+import { generateSessionId, validateKanjiSelection } from '@majibattle/shared';
+
+export class GameSession {
+  constructor(
+    // eslint-disable-next-line no-undef
+    private state: DurableObjectState,
+
+    private env: Env
+  ) {}
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const method = request.method;
+
+    try {
+      // Initialize database on first access
+      await this.initializeDatabase();
+
+      switch (method) {
+        case 'POST':
+          if (url.pathname.endsWith('/create')) {
+            return await this.createSession();
+          }
+          if (url.pathname.endsWith('/select')) {
+            const body = (await request.json()) as { kanji: string };
+            return await this.updateSelection(body.kanji);
+          }
+          if (url.pathname.endsWith('/reset')) {
+            return await this.resetSession();
+          }
+          break;
+
+        case 'GET':
+          if (url.pathname.endsWith('/state')) {
+            return await this.getState();
+          }
+          break;
+
+        default:
+          return this.errorResponse('Method not allowed', 405);
+      }
+
+      return this.errorResponse('Not found', 404);
+    } catch (error) {
+      console.error('GameSession error:', error);
+      return this.errorResponse('Internal server error', 500);
+    }
+  }
+
+  private async initializeDatabase(): Promise<void> {
+    await this.state.storage.sql.exec(`
+      CREATE TABLE IF NOT EXISTS game_sessions (
+        id INTEGER PRIMARY KEY,
+        session_id TEXT UNIQUE NOT NULL,
+        current_kanji TEXT NOT NULL,
+        selected_kanji TEXT NOT NULL,
+        spell_history TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        last_updated_at INTEGER NOT NULL
+      )
+    `);
+  }
+
+  private async createSession(): Promise<Response> {
+    const sessionId = generateSessionId();
+    const now = Date.now();
+
+    // Generate initial 20 random kanji (placeholder for Phase 3)
+    const currentKanji = this.generatePlaceholderKanji();
+
+    const sessionState: GameSessionState = {
+      sessionId,
+      currentKanji,
+      selectedKanji: [],
+      spellHistory: [],
+      createdAt: new Date(now),
+      lastUpdatedAt: new Date(now),
+    };
+
+    await this.state.storage.sql.exec(
+      'INSERT OR REPLACE INTO game_sessions (session_id, current_kanji, selected_kanji, spell_history, created_at, last_updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+      sessionId,
+      JSON.stringify(currentKanji),
+      JSON.stringify([]),
+      JSON.stringify([]),
+      now,
+      now
+    );
+
+    return this.successResponse(sessionState);
+  }
+
+  private async getState(): Promise<Response> {
+    const result = await this.state.storage.sql.exec(
+      'SELECT * FROM game_sessions ORDER BY last_updated_at DESC LIMIT 1'
+    );
+
+    const rows = result.toArray();
+    if (!rows.length) {
+      return this.errorResponse('No session found', 404);
+    }
+
+    const row = rows[0];
+    const sessionState: GameSessionState = {
+      sessionId: row.session_id as string,
+      currentKanji: JSON.parse(row.current_kanji as string),
+      selectedKanji: JSON.parse(row.selected_kanji as string),
+      spellHistory: JSON.parse(row.spell_history as string),
+      createdAt: new Date(row.created_at as number),
+      lastUpdatedAt: new Date(row.last_updated_at as number),
+    };
+
+    return this.successResponse(sessionState);
+  }
+
+  private async updateSelection(kanji: string): Promise<Response> {
+    const stateResponse = await this.getState();
+    if (!stateResponse.ok) {
+      return stateResponse;
+    }
+
+    const { data: currentState } = (await stateResponse.json()) as APIResponse<GameSessionState>;
+    if (!currentState) {
+      return this.errorResponse('Session state not found', 404);
+    }
+
+    // Validate kanji selection
+    if (!validateKanjiSelection(currentState.selectedKanji, kanji)) {
+      return this.errorResponse('Invalid kanji selection: maximum 4 or already selected', 400);
+    }
+
+    if (!currentState.currentKanji.includes(kanji)) {
+      return this.errorResponse('Kanji not available in current selection', 400);
+    }
+
+    const updatedSelectedKanji = [...currentState.selectedKanji, kanji];
+    const now = Date.now();
+
+    await this.state.storage.sql.exec(
+      'UPDATE game_sessions SET selected_kanji = ?, last_updated_at = ? WHERE session_id = ?',
+      JSON.stringify(updatedSelectedKanji),
+      now,
+      currentState.sessionId
+    );
+
+    const updatedState: GameSessionState = {
+      ...currentState,
+      selectedKanji: updatedSelectedKanji,
+      lastUpdatedAt: new Date(now),
+    };
+
+    return this.successResponse(updatedState);
+  }
+
+  private async resetSession(): Promise<Response> {
+    const stateResponse = await this.getState();
+    if (!stateResponse.ok) {
+      return stateResponse;
+    }
+
+    const { data: currentState } = (await stateResponse.json()) as APIResponse<GameSessionState>;
+    if (!currentState) {
+      return this.errorResponse('Session state not found', 404);
+    }
+
+    const now = Date.now();
+    const newKanji = this.generatePlaceholderKanji();
+
+    await this.state.storage.sql.exec(
+      'UPDATE game_sessions SET current_kanji = ?, selected_kanji = ?, last_updated_at = ? WHERE session_id = ?',
+      JSON.stringify(newKanji),
+      JSON.stringify([]),
+      now,
+      currentState.sessionId
+    );
+
+    const resetState: GameSessionState = {
+      ...currentState,
+      currentKanji: newKanji,
+      selectedKanji: [],
+      lastUpdatedAt: new Date(now),
+    };
+
+    return this.successResponse(resetState);
+  }
+
+  private generatePlaceholderKanji(): string[] {
+    // Placeholder implementation - will be replaced in Phase 3
+    const commonKanji = [
+      '火',
+      '水',
+      '木',
+      '金',
+      '土',
+      '光',
+      '闇',
+      '風',
+      '雷',
+      '氷',
+      '剣',
+      '盾',
+      '魔',
+      '法',
+      '術',
+      '攻',
+      '守',
+      '癒',
+      '破',
+      '創',
+    ];
+
+    const shuffled = [...commonKanji].sort(() => Math.random() - 0.5);
+    return shuffled.slice(0, 20);
+  }
+
+  private successResponse<T>(data: T): Response {
+    const response: APIResponse<T> = {
+      success: true,
+      data,
+    };
+    return new Response(JSON.stringify(response), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  private errorResponse(error: string, status: number): Response {
+    const response: APIResponse<null> = {
+      success: false,
+      error,
+    };
+    return new Response(JSON.stringify(response), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}
+
+// Type definitions for Cloudflare Workers
+interface Env {
+  // eslint-disable-next-line no-undef
+  GAME_SESSION: DurableObjectNamespace;
+}

--- a/packages/workers/src/index.ts
+++ b/packages/workers/src/index.ts
@@ -1,15 +1,7 @@
 // Cloudflare Workers サンプルアプリケーション
 
-interface Env {
-  // eslint-disable-next-line no-undef
-  GAME_SESSION: DurableObjectNamespace;
-}
-
-// Phase 1 placeholder types - will be replaced with proper imports in Phase 2
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-declare const DurableObjectState: any;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-declare const DurableObjectNamespace: any;
+// Import proper GameSession implementation
+export { GameSession } from './durable-objects/GameSession';
 
 export const sampleData = ['Hello', 'World', 'AI', 'Driven', 'Development'];
 
@@ -80,19 +72,6 @@ function generateHTML(message: string): string {
 </body>
 </html>
   `;
-}
-
-// Placeholder GameSession Durable Object for Phase 1
-export class GameSession {
-  constructor(
-    // eslint-disable-next-line no-undef
-    private state: DurableObjectState,
-    private env: Env
-  ) {}
-
-  async fetch(_request: Request): Promise<Response> {
-    return new Response('GameSession placeholder', { status: 200 });
-  }
 }
 
 export default {


### PR DESCRIPTION
## Summary
- SQLiteバックエンドを使用したGameSession Durable Objectの実装
- CRUD操作の実装（createSession, getState, updateSelection, resetSession）
- 漢字選択バリデーション機能の実装
- 11個の包括的なテストケースを追加

## 実装内容
- **GameSession Durable Object**: SQLiteを使用した永続化状態管理
- **データベース設計**: game_sessionsテーブルでセッション状態を管理
- **API エンドポイント**: 
  - `POST /create` - 新しいセッション作成
  - `GET /state` - セッション状態取得
  - `POST /select` - 漢字選択
  - `POST /reset` - セッションリセット
- **バリデーション**: 重複選択防止、最大4文字制限
- **エラーハンドリング**: 適切なHTTPステータスコードとエラーメッセージ

## Test plan
- [x] TypeScript型チェック通過
- [x] ESLint静的解析通過
- [x] 11個の単体テストすべて通過
- [x] データベース初期化テスト
- [x] セッション作成・取得テスト
- [x] 漢字選択バリデーションテスト
- [x] エラーハンドリングテスト
- [x] ローカル開発環境での動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)