### PR TITLE
Fix CI deployment command duplicate --env flag error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,9 @@ jobs:
         run: npm run build
 
       - name: Deploy to production
-        run: npm run deploy --workspace=@majibattle/workers -- --env production
+        run: |
+          cd packages/workers
+          npx wrangler deploy --env production
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "wrangler dev src/index.ts",
     "build": "vite build",
-    "deploy": "wrangler deploy --env production",
+    "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Fix CI deployment failure caused by duplicate --env flag
- Use npx wrangler directly in CI workflow instead of npm script
- Remove environment specification from package.json deploy script

## Problem
The CI was failing with:
```
✘ [ERROR] The argument "--env" expects a single value, but received multiple: ["production","production"].
```

This was caused by the npm workspace command passing arguments incorrectly.

## Solution
- CI workflow now uses `npx wrangler deploy --env production` directly
- package.json deploy script remains environment-agnostic for local development flexibility

## Test plan
- [x] Verify CI workflow syntax is correct
- [ ] CI/CD pipeline passes all tests
- [ ] Production deployment succeeds without duplicate flag error

🤖 Generated with [Claude Code](https://claude.ai/code)