### PR TITLE
Fix production session ID mismatch issue

### DIFF
--- a/packages/workers/src/__tests__/GameSession.test.ts
+++ b/packages/workers/src/__tests__/GameSession.test.ts
@@ -31,7 +31,11 @@ describe('GameSession Durable Object', () => {
     test('should initialize database table on first access', async () => {
       mockSqlStorage.exec.mockResolvedValueOnce({ toArray: () => [] });
 
-      const request = new Request('http://localhost/create', { method: 'POST' });
+      const request = new Request('http://localhost/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
       await gameSession.fetch(request);
 
       expect(mockSqlStorage.exec).toHaveBeenCalledWith(
@@ -46,7 +50,11 @@ describe('GameSession Durable Object', () => {
         .mockResolvedValueOnce({ toArray: () => [] }) // CREATE TABLE
         .mockResolvedValueOnce({ toArray: () => [] }); // INSERT
 
-      const request = new Request('http://localhost/create', { method: 'POST' });
+      const request = new Request('http://localhost/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
       const response = await gameSession.fetch(request);
 
       expect(response.status).toBe(200);
@@ -143,6 +151,7 @@ describe('GameSession Durable Object', () => {
 
       const request = new Request('http://localhost/select', {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ kanji: '火' }),
       });
       const response = await gameSession.fetch(request);
@@ -161,6 +170,7 @@ describe('GameSession Durable Object', () => {
 
       const request = new Request('http://localhost/select', {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ kanji: '雷' }),
       });
       const response = await gameSession.fetch(request);
@@ -184,6 +194,7 @@ describe('GameSession Durable Object', () => {
 
       const request = new Request('http://localhost/select', {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ kanji: '土' }),
       });
       const response = await gameSession.fetch(request);
@@ -212,7 +223,11 @@ describe('GameSession Durable Object', () => {
         .mockResolvedValueOnce({ toArray: () => [mockSessionData] }) // SELECT
         .mockResolvedValueOnce({ toArray: () => [] }); // UPDATE
 
-      const request = new Request('http://localhost/reset', { method: 'POST' });
+      const request = new Request('http://localhost/reset', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
       const response = await gameSession.fetch(request);
 
       expect(response.status).toBe(200);
@@ -229,7 +244,11 @@ describe('GameSession Durable Object', () => {
     test('should handle database errors gracefully', async () => {
       mockSqlStorage.exec.mockRejectedValueOnce(new Error('Database error'));
 
-      const request = new Request('http://localhost/create', { method: 'POST' });
+      const request = new Request('http://localhost/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
       const response = await gameSession.fetch(request);
 
       expect(response.status).toBe(500);

--- a/packages/workers/src/durable-objects/GameSession.ts
+++ b/packages/workers/src/durable-objects/GameSession.ts
@@ -43,21 +43,21 @@ export class GameSession {
           error: 'Durable Object initialization failed',
           details: this.initError.message,
           stack: this.initError.stack,
-          sqlAvailable: typeof this.state.storage.sql
+          sqlAvailable: typeof this.state.storage.sql,
         }),
-        { 
+        {
           status: 500,
-          headers: { 'Content-Type': 'application/json' }
+          headers: { 'Content-Type': 'application/json' },
         }
       );
     }
 
     try {
-
       switch (method) {
         case 'POST':
           if (url.pathname.endsWith('/create')) {
-            return await this.createSession();
+            const body = (await request.json()) as { sessionId?: string };
+            return await this.createSession(body.sessionId);
           }
           if (url.pathname.endsWith('/select')) {
             const body = (await request.json()) as { kanji: string };
@@ -90,7 +90,7 @@ export class GameSession {
     console.log('initializeDatabase: state.storage available:', !!this.state.storage);
     console.log('initializeDatabase: state.storage.sql available:', !!this.state.storage.sql);
     console.log('initializeDatabase: SQL exec type:', typeof this.state.storage.sql?.exec);
-    
+
     try {
       await this.state.storage.sql.exec(`
         CREATE TABLE IF NOT EXISTS game_sessions (
@@ -110,8 +110,8 @@ export class GameSession {
     }
   }
 
-  private async createSession(): Promise<Response> {
-    const sessionId = generateSessionId();
+  private async createSession(providedSessionId?: string): Promise<Response> {
+    const sessionId = providedSessionId || generateSessionId();
     const now = Date.now();
 
     // Generate initial 20 random kanji using KanjiDataManager

--- a/packages/workers/src/durable-objects/GameSessionV2.ts
+++ b/packages/workers/src/durable-objects/GameSessionV2.ts
@@ -60,7 +60,8 @@ export class GameSessionV2 {
       switch (method) {
         case 'POST':
           if (url.pathname.endsWith('/create')) {
-            return await this.createSession();
+            const body = (await request.json()) as { sessionId?: string };
+            return await this.createSession(body.sessionId);
           }
           if (url.pathname.endsWith('/select')) {
             const body = (await request.json()) as { kanji: string };
@@ -113,8 +114,8 @@ export class GameSessionV2 {
     }
   }
 
-  private async createSession(): Promise<Response> {
-    const sessionId = generateSessionId();
+  private async createSession(providedSessionId?: string): Promise<Response> {
+    const sessionId = providedSessionId || generateSessionId();
     const now = Date.now();
 
     // Generate initial 20 random kanji using KanjiDataManager

--- a/packages/workers/src/durable-objects/GameSessionV3.ts
+++ b/packages/workers/src/durable-objects/GameSessionV3.ts
@@ -60,7 +60,8 @@ export class GameSessionV3 {
       switch (method) {
         case 'POST':
           if (url.pathname.endsWith('/create')) {
-            return await this.createSession();
+            const body = (await request.json()) as { sessionId?: string };
+            return await this.createSession(body.sessionId);
           }
           if (url.pathname.endsWith('/select')) {
             const body = (await request.json()) as { kanji: string };
@@ -113,8 +114,8 @@ export class GameSessionV3 {
     }
   }
 
-  private async createSession(): Promise<Response> {
-    const sessionId = generateSessionId();
+  private async createSession(providedSessionId?: string): Promise<Response> {
+    const sessionId = providedSessionId || generateSessionId();
     const now = Date.now();
 
     // Generate initial 20 random kanji using KanjiDataManager

--- a/packages/workers/src/index.ts
+++ b/packages/workers/src/index.ts
@@ -956,6 +956,8 @@ async function createNewGameSession(
   const response = await durableObject.fetch(
     new Request('https://fake-host/create', {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId }),
     })
   );
 
@@ -1095,7 +1097,10 @@ async function generateSpell(
       });
     }
 
-    const sessionData = (await stateResponse.json()) as { success: boolean; data?: { selectedKanji?: string[] } };
+    const sessionData = (await stateResponse.json()) as {
+      success: boolean;
+      data?: { selectedKanji?: string[] };
+    };
 
     if (!sessionData.success || !sessionData.data) {
       return new Response(JSON.stringify({ error: 'Invalid session state' }), {


### PR DESCRIPTION
## Summary
- Fix 404 errors in production caused by session ID mismatch
- Ensure client-side session ID matches the one stored in Durable Object
- Update all GameSession versions to accept provided session ID

## Problem
In production, the application was failing with 404 errors when trying to access game sessions. The root cause was:
1. `index.ts` generates a session ID using `crypto.randomUUID()`
2. Durable Objects generate their own session ID using `generateSessionId()`
3. Client uses the first ID, but Durable Object stores the second ID
4. Result: 404 errors when trying to access the session

## Solution
- Pass the session ID from `index.ts` to Durable Objects during creation
- Update all GameSession versions (V1, V2, V3) to accept an optional `providedSessionId`
- If provided, use that ID; otherwise, generate a new one

## Test plan
- [x] Unit tests pass
- [ ] Deploy to staging and verify session creation/access works
- [ ] Deploy to production and verify 404 errors are resolved

🤖 Generated with [Claude Code](https://claude.ai/code)